### PR TITLE
Wrap call to select2 initialization in JS function `initializeSelect2…

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,12 @@ Changelog
   the profile to add a css in portal_css.
   [cedricmessiant]
 
+- Wrap call to select2 initialization in JS function `initializeSelect2Widgets`
+  so it is easy to call from everywhere (like in an overlay initialization).
+  Parameter width can be specified when calling `initializeSelect2Widgets`
+  and defaults to `resolve`.
+  [gbastien]
+
 
 1.2 (2016-08-25)
 ----------------

--- a/src/collective/z3cform/select2/browser/static/select2-widget.js
+++ b/src/collective/z3cform/select2/browser/static/select2-widget.js
@@ -1,4 +1,4 @@
-jQuery(document).ready(function($) {
+initializeSelect2Widgets = function(width='resolve') {
 
   var format = function(state) {
       var option = $(state.element);
@@ -6,7 +6,7 @@ jQuery(document).ready(function($) {
   };
 
   $('.single-select2-widget').select2({
-      width: 'resolve',
+      width: width,
       formatResult: format,
       formatSelection: format,
       escapeMarkup: function(m) { return m; },
@@ -18,4 +18,6 @@ jQuery(document).ready(function($) {
     escapeMarkup: function(m) { return m; },
   });
 
-});
+};
+
+jQuery(document).ready(initializeSelect2Widgets);


### PR DESCRIPTION
…Widgets` so it is easy to call from everywhere (like in an overlay initialization). Parameter width can be specified when calling `initializeSelect2Widgets` and defaults to `resolve`.

Could you please review/merge ;-)

Gauthier