### PR TITLE
- Make faceted widget compatible with eea.facetednavigation 10+

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,12 @@ Changelog
 =========
 
 
-1.4.2 (unreleased)
+2.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Make faceted widget compatible with eea.facetednavigation 10+.
+  This makes it no more compatible with eea.facetednavigation<10.
+  [gbastien]
 
 
 1.4.1 (2017-12-01)

--- a/README.rst
+++ b/README.rst
@@ -68,6 +68,12 @@ and then running ``bin/buildout``
 You need to install the collective.z3cform.select2 addon to register the
 select2 js library. In a facetednav, add a Select2 criterion.
 
+eea.facetednavigation
+---------------------
+
+Version 2.0.0+ is only working with eea.facetednavigation 10+.
+If you need to make it work with eea.facetednavigation < 10, use versions < 2.0.0
+
 
 Contribute
 ----------

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ long_description = (
 
 setup(
     name='collective.z3cform.select2',
-    version='1.4.2.dev0',
+    version='2.0.0.dev0',
     description="select2 widget for z3c.form and eea.facetednavigation",
     long_description=long_description,
     # Get more from https://pypi.python.org/pypi?%3Aaction=list_classifiers
@@ -45,8 +45,7 @@ setup(
     install_requires=[
         'setuptools',
         'plone.api',
-        'eea.facetednavigation < 10.0',
-        'eea.jquery >= 8.8',
+        'eea.facetednavigation>=10.0',
         'z3c.form >= 3.2.11',
     ],
     extras_require={

--- a/src/collective/z3cform/select2/browser/configure.zcml
+++ b/src/collective/z3cform/select2/browser/configure.zcml
@@ -15,6 +15,7 @@
     layer="collective.z3cform.select2.interfaces.ICollectiveZ3CformSelect2Layer"
     />
 
-  <faceted:widget factory=".select2widget.Widget" />
+  <faceted:widget factory=".select2widget.Widget"
+                  schema=".select2widget.ISelect2Schema" />
 
 </configure>

--- a/src/collective/z3cform/select2/browser/select2widget.py
+++ b/src/collective/z3cform/select2/browser/select2widget.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 from eea.facetednavigation.widgets import ViewPageTemplateFile
 from eea.facetednavigation.widgets.select.widget import Widget as SelectWidget
+from eea.facetednavigation.widgets.select.interfaces import ISelectSchema
+
 from eea.faceted.vocabularies.utils import compare
 
 from zope.i18n import MessageFactory
 
 _ = MessageFactory('collective.z3cform.select2')
+
+
+class ISelect2Schema(ISelectSchema):
+    """ """
 
 
 class Widget(SelectWidget):

--- a/src/collective/z3cform/select2/browser/select2widget.py
+++ b/src/collective/z3cform/select2/browser/select2widget.py
@@ -18,8 +18,6 @@ class Widget(SelectWidget):
     """ Widget
     """
 
-    view_js = '++resource++faceted.select2.view.js'
-
     # Widget properties
     widget_type = 'select2'
     widget_label = _('Select2')

--- a/src/collective/z3cform/select2/browser/templates/select2-view.js
+++ b/src/collective/z3cform/select2/browser/templates/select2-view.js
@@ -53,7 +53,7 @@ if (typeof(Faceted) != 'undefined') {
       jQuery('#' + jQuery(this).data('select2-open')).select2('open');
     });
     select.siblings('.select2-container')[0].style.minWidth = '200px';
-    select.addClass('init-select2-done')
+    select.addClass('init-select2-done');
   };
 
 

--- a/src/collective/z3cform/select2/minimal.zcml
+++ b/src/collective/z3cform/select2/minimal.zcml
@@ -23,4 +23,14 @@
       provides="Products.GenericSetup.interfaces.EXTENSION"
       />
 
+  <genericsetup:upgradeSteps
+      source="1000"
+      destination="2000"
+      profile="collective.z3cform.select2:default">
+      <genericsetup:upgradeDepends
+          title="Update registered JS resources"
+          description="Reorder an update JS resources definition"
+          import_steps="jsregistry" />
+  </genericsetup:upgradeSteps>
+
 </configure>

--- a/src/collective/z3cform/select2/profiles/default/jsregistry.xml
+++ b/src/collective/z3cform/select2/profiles/default/jsregistry.xml
@@ -8,14 +8,16 @@
     enabled="1"
     expression=""
     id="++resource++faceted.select2.view.js"
+    insert-after="++resource++eea.facetednavigation.widgets.text.view.js"
+    bundle="faceted-view"
     />
 
   <javascript
     cacheable="True"
     compression="safe"
     cookable="True"
-    enabled="1"
     expression=""
+    enabled="1"
     authenticated="True"
     id="++resource++select2-widget/select2-widget.js"
     />

--- a/src/collective/z3cform/select2/profiles/default/metadata.xml
+++ b/src/collective/z3cform/select2/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>1000</version>
+  <version>2000</version>
   <dependencies>
     <dependency>profile-eea.jquery:23-select2</dependency>
   </dependencies>


### PR DESCRIPTION
This makes it no more compatible with eea.facetednavigation<10...

Hi @vincentfretin @bsuttor @sgeulette 

I adapted code so it is working with eea.facetednavigation 10.  I also adapted faceted widget JS registration so it is inserted after eea.facetednav js and added an upgrade step.

Next step will be to make it work on Plone5...

Could you please review but NOT MERGE until a branch 1.4.x is created to save current master status working with eea.facetednavigation < 10...

Thank you!

Gauthier